### PR TITLE
Fixed the order in which Directives wraps Resolver when being set multiple directives

### DIFF
--- a/codegen/field.go
+++ b/codegen/field.go
@@ -88,7 +88,7 @@ func (b *builder) bindField(obj *Object, f *Field) (errret error) {
 			if err != nil {
 				errret = err
 			}
-			f.Directives = append(dirs, f.Directives...)
+			f.Directives = append(f.Directives, dirs...)
 		}
 	}()
 
@@ -418,7 +418,7 @@ func (f *Field) ImplDirectives() []*Directive {
 	}
 	for i := range f.Directives {
 		if !f.Directives[i].Builtin && f.Directives[i].IsLocation(loc) {
-			d = append(d, f.Directives[i])
+			d = append([]*Directive{f.Directives[i]}, d...)
 		}
 	}
 	return d

--- a/codegen/testserver/directive_test.go
+++ b/codegen/testserver/directive_test.go
@@ -155,10 +155,14 @@ func TestDirectives(t *testing.T) {
 				return nil, nil
 			},
 			Directive1: func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
-				return next(ctx)
+				res, err = next(ctx)
+				ok := "dir1_" + *(res.(*string)) + "_dir1"
+				return &ok, err
 			},
 			Directive2: func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
-				return next(ctx)
+				res, err = next(ctx)
+				ok := "dir2_" + *(res.(*string)) + "_dir2"
+				return &ok, err
 			},
 			Order: func(ctx context.Context, obj interface{}, next graphql.Resolver, location string) (res interface{}, err error) {
 				order := []string{location}
@@ -257,7 +261,7 @@ func TestDirectives(t *testing.T) {
 
 			c.MustPost(`query { directiveDouble }`, &resp)
 
-			require.Equal(t, "Ok", resp.DirectiveDouble)
+			require.Equal(t, "dir1_dir2_Ok_dir2_dir1", resp.DirectiveDouble)
 		})
 
 		t.Run("directive is not implemented", func(t *testing.T) {

--- a/codegen/testserver/generated.go
+++ b/codegen/testserver/generated.go
@@ -6338,16 +6338,16 @@ func (ec *executionContext) _Query_directiveDouble(ctx context.Context, field gr
 			return ec.resolvers.Query().DirectiveDouble(rctx)
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			if ec.directives.Directive1 == nil {
-				return nil, errors.New("directive directive1 is not implemented")
-			}
-			return ec.directives.Directive1(ctx, nil, directive0)
-		}
-		directive2 := func(ctx context.Context) (interface{}, error) {
 			if ec.directives.Directive2 == nil {
 				return nil, errors.New("directive directive2 is not implemented")
 			}
-			return ec.directives.Directive2(ctx, nil, directive1)
+			return ec.directives.Directive2(ctx, nil, directive0)
+		}
+		directive2 := func(ctx context.Context) (interface{}, error) {
+			if ec.directives.Directive1 == nil {
+				return nil, errors.New("directive directive1 is not implemented")
+			}
+			return ec.directives.Directive1(ctx, nil, directive1)
 		}
 
 		tmp, err := directive2(rctx)
@@ -7820,16 +7820,16 @@ func (ec *executionContext) _Subscription_directiveDouble(ctx context.Context, f
 			return ec.resolvers.Subscription().DirectiveDouble(rctx)
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			if ec.directives.Directive1 == nil {
-				return nil, errors.New("directive directive1 is not implemented")
-			}
-			return ec.directives.Directive1(ctx, nil, directive0)
-		}
-		directive2 := func(ctx context.Context) (interface{}, error) {
 			if ec.directives.Directive2 == nil {
 				return nil, errors.New("directive directive2 is not implemented")
 			}
-			return ec.directives.Directive2(ctx, nil, directive1)
+			return ec.directives.Directive2(ctx, nil, directive0)
+		}
+		directive2 := func(ctx context.Context) (interface{}, error) {
+			if ec.directives.Directive1 == nil {
+				return nil, errors.New("directive directive1 is not implemented")
+			}
+			return ec.directives.Directive1(ctx, nil, directive1)
 		}
 
 		tmp, err := directive2(rctx)


### PR DESCRIPTION
Assume defined following schema
```
directive @directive1 on FIELD_DEFINITION
directive @directive2 on FIELD_DEFINITION

extend type Query {
    directiveDouble: String @directive1 @directive2
}
```
In this case, I expected that directive function executed in order (`directive1 → directive2`). 
But actually executed in reverse order(`directive2 → directive1`).

This PR fixes the execution order to `directive1 → directive2` when multiple directives are setted at the same location.

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
